### PR TITLE
Add a printGitDiffToFile option

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ $ sbt --error 'set showSuccess := false' git-diff-all  # suppress sbt debug log
 - `gitDiffSeparator` : Specify separator string for printing projects. `\n` as default.
 - `printGitDiffByBaseDirectory` : Print base directory instead of project ID. `false` as default.
 - `printGitDiffByAbsolutePath` : Print absolute path instead of related path. (only affects when `printGitDiffByBaseDirectory` is true) `false` by default.
+- `printGitDiffToFile` : Print to a file instead of stdout. `None` (print to stdout) by default.
 - `excludeRootProject` : This plugin derives project-diff based on project's base directory. Since root project's base directory-path is included to any project's, excluding root project from diff is reasonable. `true` by default.
 - `patternsAffectAllProjects` : For some special files, you would want to force testing all projects if the file is modified. (e.g. `.travis.yml`, `circle.yml`, `build.sbt`, ...) `Seq(""".+\.sbt$""", """.+project/[^/]+\.scala""")` by default.
 

--- a/src/main/scala/jp/ne/opt/sbt/diff/SbtPlugin.scala
+++ b/src/main/scala/jp/ne/opt/sbt/diff/SbtPlugin.scala
@@ -1,5 +1,7 @@
 package jp.ne.opt.sbt.diff
 
+import java.io.PrintStream
+
 import sbt._
 import Keys._
 import complete.Parsers.spaceDelimited
@@ -16,6 +18,7 @@ object SbtPlugin extends AutoPlugin {
     gitDiffSeparator in Global := "\n",
     printGitDiffByBaseDirectory in Global := false,
     printGitDiffByAbsolutePath in Global := false,
+    printGitDiffToFile in Global := None,
     excludeRootProject in Global := true,
     patternsAffectAllProjects in Global := Seq(
       """.+\.sbt$""",
@@ -58,7 +61,8 @@ object SbtPlugin extends AutoPlugin {
         buildRoot,
         gitDiffSeparator.value,
         printGitDiffByBaseDirectory.value,
-        printGitDiffByAbsolutePath.value)
+        printGitDiffByAbsolutePath.value,
+        printGitDiffToFile.value)
 
       modifiedState
     }
@@ -71,7 +75,11 @@ object SbtPlugin extends AutoPlugin {
                                   buildRoot: File,
                                   separator: String,
                                   byBaseDirectory: Boolean,
-                                  byAbsolutePath: Boolean): Unit = {
+                                  byAbsolutePath: Boolean,
+                                  toFile: Option[File]): Unit = {
+
+    val out = toFile.fold(System.out)(new PrintStream(_))
+
     projects.headOption.foreach { _ =>
       val str = projects.map { project =>
         if (!byBaseDirectory) {
@@ -83,7 +91,7 @@ object SbtPlugin extends AutoPlugin {
         }
       }.sorted mkString separator
 
-      println(str)
+      out.println(str)
     }
   }
 }

--- a/src/main/scala/jp/ne/opt/sbt/diff/SbtPluginKeys.scala
+++ b/src/main/scala/jp/ne/opt/sbt/diff/SbtPluginKeys.scala
@@ -12,6 +12,8 @@ trait SbtPluginKeys {
     "Print base directory instead of project ID.")
   val printGitDiffByAbsolutePath = SettingKey[Boolean]("print-git-diff-by-absolute-path",
     "Print absolute path instead of related path. This option only affects when printGitDiffByBaseDirectory is true.")
+  val printGitDiffToFile = SettingKey[Option[File]]("print-git-diff-to-file",
+    "Print to a file instead of to stdout.")
   val excludeRootProject = SettingKey[Boolean]("exclude-root-project",
     "Specify if results should exclude root project for git-diff-all command.")
   val patternsAffectAllProjects = SettingKey[Seq[String]]("patterns-affect-all-projects",


### PR DESCRIPTION
Even when calling SBT with `sbt --error 'set showSuccess := false'`, there are messages that still get printed to stdout on the current SBT version. Since SBT doesn't have a reliable way to control how the output of SBT itself and its plugins get printed, the most reliable way is to print the diff to a file and read it externally afterwards.

This PR adds a `printGitDiffToFile` SBT setting that controls whether the output gets printed to stdout or to a file, with the default being the current behavior.
